### PR TITLE
Use linebreaks to split commandline options

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+ansible
+ansible-lint
+molecule
+molecule-docker

--- a/tasks/ca.yml
+++ b/tasks/ca.yml
@@ -22,13 +22,23 @@
     mode: 0600
 
 - name: Generate CA key
-  command: "openssl genrsa -out {{ ca_ca_dir }}/ca.key {{ ca_ca_keylength }}"
+  command: >
+    openssl genrsa
+    -out {{ ca_ca_dir }}/ca.key
+    {{ ca_ca_keylength }}
   args:
     creates: "{{ ca_ca_dir }}/ca.key"
 
 - name: Generate CA certificate
   command: >
-    "openssl req -x509 -new -nodes -key {{ ca_ca_dir }}/ca.key -sha256 -days
-    3650 -out {{ ca_ca_dir }}/ca.crt -config {{ ca_ca_dir }}/ca.conf"
+    openssl req
+    -x509
+    -new
+    -nodes
+    -key {{ ca_ca_dir }}/ca.key
+    -sha256
+    -days 3650
+    -out {{ ca_ca_dir }}/ca.crt
+    -config {{ ca_ca_dir }}/ca.conf
   args:
     creates: "{{ ca_ca_dir }}/ca.crt"


### PR DESCRIPTION
fixes #4